### PR TITLE
Fix issues with duplicated users in database

### DIFF
--- a/src/i18n/translations.js
+++ b/src/i18n/translations.js
@@ -14,6 +14,8 @@ export default {
     "instructions.command_title": "Comando para bot ou GET direto na api",
     "instructions.command_text":
       'Caso queira criar, por exemplo, um comando "!song" usando um bot da Twitch, basta utilizar a url de GET da api abaixo. A resposta será um texto com a música atual.',
+    "issues.text": "Tem problemas?",
+    "relogin_button.text" : "Reconectar com ou Spotify",
     built_with: "feito com",
     by_francisco: "por {github}",
     icons_credits: "Ícones por {freepik} no {flaticon}",
@@ -34,6 +36,8 @@ export default {
     "instructions.command_title": "Command for bot or GET direct in the api",
     "instructions.command_text":
       'If you want to create, for example, a "!song" command using a Twitch bot, just use the GET url from the api below. The answer will be a text with the current song.',
+    "issues.text": "Having issues?",
+    "relogin_button.text": "Reconnect with Spotify",
     built_with: "feito com",
     built_with: "built with",
     by_francisco: "by {github}",

--- a/src/pages/api/user/index.js
+++ b/src/pages/api/user/index.js
@@ -4,7 +4,7 @@ import { useCors } from '../../../middlewares/cors'
 
 export default async function handler(req, res) {
   await useCors(req, res)
-  
+
   const {
     method,
   } = req
@@ -12,11 +12,21 @@ export default async function handler(req, res) {
   await dbConnect()
 
   switch (method) {
-
     case 'POST':
       try {
-        const user = await User.create(req.body) 
-        res.status(201).json({ success: true, data: user })
+        await User.find({ user: req.body.user }, async (err, users) => {
+          if (!err && users.length > 1) {
+            await User.deleteMany({ user: req.body.user })
+            const user = await User.create(req.body)
+            res.status(201).json({ success: true, data: user })
+          } else if (!err && users.length == 1) {
+            const user = await User.findOneAndUpdate({user: req.body.user}, req.body)
+            res.status(201).json({ success: true, data: user })
+          } else if (!err && users.length == 0) {
+            const user = await User.create(req.body)
+            res.status(201).json({ success: true, data: user })
+          }
+        });
       } catch (error) {
         res.status(400).json({ success: false })
       }

--- a/src/pages/index.jsx
+++ b/src/pages/index.jsx
@@ -131,13 +131,35 @@ const Home = () => {
                 <p>
                   <FormattedMessage id="instructions.command_text" />
                 </p>
-                <div style={{ textAlign: 'center', marginTop: 32 }}>
+                <div style={{ textAlign: "center", marginTop: 32 }}>
                   <Link href={`/api/now/${spotifyUser}`}>
                     <a>{`${process.env.BASE_URL}/api/now/${spotifyUser}`}</a>
                   </Link>
                 </div>
               </Col>
             </Row>
+            {spotifyUser && (
+              <Row>
+                <Col align="flex-start" xs={0.5}>
+                  <Pineapple type="designer" width={48} />
+                </Col>
+                <Col justify="center">
+                  <H2>
+                    <FormattedMessage id="issues.text" />
+                  </H2>
+                </Col>
+                <Col align="center" xs={4}>
+                  <div style={{ padding: "24px 0" }}>
+                    <Button onClick={goToSpotifyLogin}>
+                      <FaSpotify style={{ marginRight: 8 }} />
+                      <span>
+                        <FormattedMessage id="relogin_button.text" />
+                      </span>
+                    </Button>
+                  </div>
+                </Col>
+              </Row>
+            )}
           </>
         )}
         <Footer />


### PR DESCRIPTION
I've worked to resolve the problem of multiple re log ins, this is just an idea/suggestion, I did the best I could, I'm not very familiar with some parts of the code but if you or other maintainer wants to modify this or implement to the main branch, go ahead. This can also resolve this issue (#15)

__Important changes:__

- If a user registers, it will be checked if there is one, several or none, and then it will be updated in the database. This avoids getting duplicated documents in database.

- Added re login button to avoid problems when the user tries to log in again if permissions were removed from Spotify apps. Some users (like me) can't use the widget because when they try accessing to the widget page, the page uses "findOne" method, so if the user removed the app from Spotify apps it isn't possible to re login and use the widget because the token from the database is expired. Also, this will delete all duplicates and old documents that match with the user and replace it with a new one, which will generate new tokens.
_Tip: this can be modified by searching the user in database, if the user exists and the auth token isn't expired don't display the button, else display it_